### PR TITLE
remove rl.close() for windows 10's compatibility

### DIFF
--- a/hls-vod.js
+++ b/hls-vod.js
@@ -164,7 +164,7 @@ function pollForPlaylist(file, response, playlistPath) {
 			if (line.match('^#EXTINF:[0-9]+')) count++;
 			if (count >= need) {
 				found = true;
-				rl.close();
+				
 			}
 		});
 		rl.on('close', function() {

--- a/hls-vod.js
+++ b/hls-vod.js
@@ -164,7 +164,9 @@ function pollForPlaylist(file, response, playlistPath) {
 			if (line.match('^#EXTINF:[0-9]+')) count++;
 			if (count >= need) {
 				found = true;
-				
+				// We should have closed here but it causes some issues on win10.
+				// See https://github.com/mifi/hls-vod/pull/9
+				// rl.close();
 			}
 		});
 		rl.on('close', function() {


### PR DESCRIPTION
No need to close the rl.  
If this line "rl.close()" exists, it cannot run properly on windows.  It always raises exception in readStream.on('error',..) after generating 3 ts segments.
It works well on Mac, Linux and windows after removing this line.